### PR TITLE
Introduce a pre-build grunt task

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,6 +20,7 @@ npm.cmd
 # Ignore generated files
 patternfly.spec
 build
+source/_includes/widgets
 =======
 _site
 public

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "submodules/patternfly-core"]
+	path = submodules/patternfly-core
+	url = https://github.com/patternfly/patternfly.git

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -40,6 +40,15 @@ module.exports = function (grunt) {
         }
       }
     },
+    copy: {
+      prebuild: {
+        files: [
+          // Copy resources from git submodules, node_modules, or bower components
+          // This copy command replaces the symlink currently in place
+          {expand: true, cwd: 'source/components/patternfly/tests/pages/_includes/widgets', src: ['**'], dest: 'source/_includes/widgets'},
+        ]
+      }
+    },
     csscount: {
       source: {
         src: [
@@ -141,7 +150,12 @@ module.exports = function (grunt) {
     'uglify'
   ]);
 
+  grunt.registerTask('prebuild', [
+    'copy:prebuild'
+  ])
+
   grunt.registerTask('build', [
+    'prebuild',
     'less',
     'cssmin',
     //'csscount',

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -40,12 +40,24 @@ module.exports = function (grunt) {
         }
       }
     },
+    run: {
+      options: {
+      },
+      submodulesUpdate: {
+        cmd: 'git',
+        args: [
+          'submodule',
+          'update',
+          '--init'
+        ]
+      }
+    },
     copy: {
       prebuild: {
         files: [
           // Copy resources from git submodules, node_modules, or bower components
           // This copy command replaces the symlink currently in place
-          {expand: true, cwd: 'source/components/patternfly/tests/pages/_includes/widgets', src: ['**'], dest: 'source/_includes/widgets'},
+          {expand: true, cwd: 'submodules/patternfly-core/tests/pages/_includes/widgets', src: ['**'], dest: 'source/_includes/widgets'},
         ]
       }
     },
@@ -151,6 +163,7 @@ module.exports = function (grunt) {
   ]);
 
   grunt.registerTask('prebuild', [
+    'run:submodulesUpdate',
     'copy:prebuild'
   ])
 

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "connect-livereload": "~0.3.0",
     "grunt": "~0.4.1",
     "grunt-contrib-connect": "~0.5.0",
+    "grunt-contrib-copy": "^1.0.0",
     "grunt-contrib-cssmin": "^0.12.3",
     "grunt-contrib-less": "^1.0.1",
     "grunt-contrib-uglify": "~0.3.2",

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "grunt-css-count": "^0.3.0",
     "grunt-jekyll": "^0.4.2",
     "grunt-jslint": "^1.1.14",
+    "grunt-run": "^0.6.0",
     "matchdep": "~0.3.0"
   },
   "description": "Documentation, etc. for PatternFly",

--- a/source/_includes/widgets
+++ b/source/_includes/widgets
@@ -1,1 +1,0 @@
-../components/patternfly/tests/pages/_includes/widgets


### PR DESCRIPTION
This PR introduces patternfly-core as a git submodule, and introduces grunt tasks to update the submodule, and copy resources out of that submodule.
